### PR TITLE
Fix missing ACL_bench imports

### DIFF
--- a/TeachMyAgent/teachers/algos/truncated_self_paced.py
+++ b/TeachMyAgent/teachers/algos/truncated_self_paced.py
@@ -4,8 +4,8 @@ import emcee
 import numpy as np
 import torch
 import scipy.linalg as scpla
-from ACL_bench.teachers.algos.AbstractTeacher import AbstractTeacher
-from ACL_bench.teachers.utils.gaussian_torch_distribution import GaussianTorchDistribution
+from TeachMyAgent.teachers.algos.AbstractTeacher import AbstractTeacher
+from TeachMyAgent.teachers.utils.gaussian_torch_distribution import GaussianTorchDistribution
 from scipy.optimize import minimize, NonlinearConstraint, Bounds
 from scipy.stats import multivariate_normal
 import itertools

--- a/TeachMyAgent/teachers/teacher_controller.py
+++ b/TeachMyAgent/teachers/teacher_controller.py
@@ -6,7 +6,7 @@ from TeachMyAgent.teachers.algos.alp_gmm import ALPGMM
 from TeachMyAgent.teachers.algos.covar_gmm import CovarGMM
 from TeachMyAgent.teachers.algos.adr import ADR
 from TeachMyAgent.teachers.algos.self_paced_teacher import SelfPacedTeacher
-from ACL_bench.teachers.algos.truncated_self_paced import SelfPacedTeacher as TruncatedSelfPacedTeacher
+from TeachMyAgent.teachers.algos.truncated_self_paced import SelfPacedTeacher as TruncatedSelfPacedTeacher
 from TeachMyAgent.teachers.algos.goal_gan import GoalGAN
 from TeachMyAgent.teachers.algos.setter_solver import SetterSolver
 from TeachMyAgent.teachers.algos.random_teacher import RandomTeacher


### PR DESCRIPTION
The line `import ACL_bench` prevents `run.py` from launching in a clean repository. I'm not exactly sure if this change is 100% correct, but at least I'm able to launch the run script. 